### PR TITLE
upgrade to Staticman v3

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -178,7 +178,7 @@ copyright = "Design/Programmierung: <a href=\"https://angel-crawford.de/\" targe
       "*.disquscdn.com"]
 
   [params.staticman]
-    endpoint = "https://article-static.herokuapp.com/v2/entry"
+    endpoint = "https://article-static.herokuapp.com/v3/entry/github"
     username = "AngelCrawford"
     repository = "blog"
     branch = "master"


### PR DESCRIPTION
# Descritpion

To update the form's POST URL according to Staticman v3 API scheme, which has been

- proposed in eduardoboucas/staticman<span>#</span>22
- implemented since eduardoboucas/staticman<span>#</span>219
- included in the official docs since eduardoboucas/staticman.net<span>#</span>13

:information_source: You need either one of the following back-end setup so that this PR would function as expected.

1. v2: include the unmerged PR eduardoboucas/staticman<span>#</span>405
2. v3: replace your GitHub bot with a (private) GitHub App

# Motivation
## Development of Staticman in recent years

The [official quick start tutorial](https://staticman.net/docs/getting-started.html) recommends the GitHub App authorization mechanism (implemented since eduardoboucas/staticman<span>#</span>255), which circumvents the known rate API limit issue (c.f. eduardoboucas/staticman<span>#</span>222, eduardoboucas/staticman<span>#</span>227, eduardoboucas/staticman<span>#</span>243) and which is available since v3.

Your Staticman API instance's greeting message features its version number (3).

![Screenshot from 2021-02-26 13-39-38](https://user-images.githubusercontent.com/5748535/109301330-18880080-7838-11eb-9f1b-2a8e515c5e9e.png)

However, your API instance is still using the legacy GitHub bot authorization method in v2.

https://github.com/AngelCrawford/blog/blob/e8bb1c535bbbf1912aa755b2a82ec274307f5db1/config.toml#L181

## Limit access to your Staticman bot
### Under v2
The `/v2/connect` route is open to public: anyone can invite then force other's GitHub bot to accept the invitation by a GET request to that route.  To close this route, you may see this article:
https://www.gabescode.com/staticman/2019/01/03/create-staticman-instance.html#keep-other-people-out

### Since v3 on GitHub

Users can make a his/her GitHub App private.  That prevents others from using it.  For details, plz see the official docs (or read the [illustrated API setup guide](https://github.com/pacollins/hugo-future-imperfect-slim/wiki/staticman.yml) that I've written for another Hugo theme).

# Analysis

The 1st linked article #1 is still based on Staticman v2.  Despite the 2nd linked article based on v3, due to the lack of documentation about the v3 API by the time you integrated Staticman to this site, getting to v3 might be a bit tricky.